### PR TITLE
Use explicit constructor arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies, run pytests
+
+name: pdberellig tests
+
+on: push
+
+jobs:
+  pytest:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+      - name: Define a cache for the virtual environment based on the dependencies lock file
+        uses: actions/cache@v3
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}
+      - run: |
+          poetry install --with dev
+          poetry run pytest --cov=pdberellig

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-added-large-files
@@ -14,7 +14,6 @@ repos:
       - id: trailing-whitespace
       - id: fix-byte-order-marker
       - id: end-of-file-fixer
-        # args: ["--maxkb=3000"]
       - id: check-ast
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9 # Ruff version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-07-27
+
+### Changed
+
+- **Breaking:** `Cofactors`, `Reactants`, and `Drugs` pipeline classes now take
+  explicit constructor arguments (`ligand_cif`, `ligand_type`, `out_dir`, `logger`,
+  etc.) instead of an `argparse.Namespace` object, so they can be used
+  programmatically without going through the CLI.
+- Cofactor reference data (RDKit templates, cofactor details, and EC numbers) is
+  now loaded via cached module-level functions (`init_rdkit_templates`,
+  `get_cofactor_details`, `get_cofactor_ec` in `pdberellig.helpers.utils`) instead
+  of being loaded once per `Cofactors` instance.
+- ChEBI structure file is now parsed using its native/perceived data types
+  instead of forcing every column to `str`, fixing comparisons against
+  `status_id` and `default_structure`.
+
+### Added
+
+- Pytest suite covering the cofactors, drugs, and reactants pipelines.
+- GitHub Actions workflow to run the test suite on pushes/PRs.
+
+### Fixed
+
+- `Drugs.get_drugbank_targets` now returns an empty `DataFrame` (instead of
+  `None`) when no DrugBank targets category is present in the CIF file,
+  preventing downstream failures.

--- a/pdberellig/cli.py
+++ b/pdberellig/cli.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 
 import click
@@ -38,8 +37,7 @@ def cofactors(cif: str, ligand_type: str, out_dir: str):
 
     log = setup_log("functional annotation pipeline", "cofactors")
 
-    args = argparse.Namespace(cif=cif, ligand_type=ligand_type, out_dir=out_dir)
-    cofactors = Cofactors(log, args)
+    cofactors = Cofactors(cif, ligand_type, out_dir, log)
     cofactors.process_entry()
 
 
@@ -102,15 +100,15 @@ def reactants(
             f"Path to the output directory ({out_dir}) does not exist."
         )
 
-    args = argparse.Namespace(
-        cif=cif,
-        ligand_type=ligand_type,
-        chebi_structure_file=chebi_structure_file,
-        update_chebi=update_chebi,
-        out_dir=out_dir,
+    reactants = Reactants(
+        cif,
+        ligand_type,
+        chebi_structure_file,
+        out_dir,
+        log,
         minimal_ligand_size=minimal_ligand_size,
+        update_chebi=update_chebi,
     )
-    reactants = Reactants(log, args)
     reactants.process_entry()
 
 
@@ -132,11 +130,5 @@ def reactants(
 def drugs(cif: str, ligand_type: str, out_dir: str):
     log = setup_log("functional annotation pipeline", "drugs")
 
-    args = argparse.Namespace(
-        cif=cif,
-        ligand_type=ligand_type,
-        out_dir=out_dir,
-    )
-
-    drugs = Drugs(log, args)
+    drugs = Drugs(cif, ligand_type, out_dir, log)
     drugs.process_entry()

--- a/pdberellig/core/cofactors.py
+++ b/pdberellig/core/cofactors.py
@@ -32,6 +32,8 @@ from pdbeccdutils.core import ccd_reader
 from pdberellig.conf import get_config, get_data_dir
 from pdberellig.core.models import CofactorSim, CompareObj, Similarity
 from pdberellig.helpers.utils import (
+    get_cofactor_details,
+    get_cofactor_ec,
     get_ligand_intx_chains,
     init_rdkit_templates,
     parse_ligand,
@@ -60,11 +62,9 @@ class Cofactors:
         # parse ligand cif file
         component = parse_ligand(self.ligand_cif, self.ligand_type)
         ligand = CompareObj(component.id, component.mol_no_h)
-        templates = init_rdkit_templates(
-            os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
-        )
-        cofactor_details = self._get_cofactor_details()
-        cofactor_details = self._get_cofactor_ec()
+        templates = init_rdkit_templates()
+        cofactor_details = get_cofactor_details()
+        cofactor_ec = get_cofactor_ec()
 
         # get similarity of the ligand to cofactor templates
         cofactor_sim = self.get_similarity(ligand)
@@ -156,14 +156,11 @@ class Cofactors:
 
         cofactor_sim = None
         if not templates:
-            templates = init_rdkit_templates(
-                os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
-            )
+            templates = init_rdkit_templates()
         if not cofactor_details:
-            cofactor_details = self._get_cofactor_details()
-
+            cofactor_details = get_cofactor_details()
         if not cofactor_ec:
-            cofactor_ec = self._get_cofactor_ec()
+            cofactor_ec = get_cofactor_ec()
 
         with ThreadPoolExecutor(max_workers=cpu_count() - 1) as exec:
             future_to_result = {
@@ -275,22 +272,3 @@ class Cofactors:
             )
 
         return representative_sim
-
-    @lru_cache
-    def _get_cofactor_details(self) -> dict:
-        """Returns the threshold and representative details of cofactor
-        classes as dictionary"""
-        path = os.path.join(
-            os.path.join(get_data_dir(), get_config("cofactor", "details")),
-        )
-        with open(path) as f:
-            obj = json.load(f)
-            return {x["template"]: x for x in obj}
-
-    @lru_cache
-    def _get_cofactor_ec(self) -> pd.DataFrame:
-        """Returns the EC numbers allowed for cofactor classes"""
-        path = os.path.join(get_data_dir(), get_config("cofactor", "ec"))
-        cofactor_ec = pd.read_csv(path, dtype={"EC_NO": str, "COFACTOR_ID": int})
-
-        return cofactor_ec

--- a/pdberellig/core/cofactors.py
+++ b/pdberellig/core/cofactors.py
@@ -22,7 +22,6 @@ Cofactors pipeline data model
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from functools import lru_cache
 from multiprocessing import cpu_count
 from typing import List, Union
 

--- a/pdberellig/core/cofactors.py
+++ b/pdberellig/core/cofactors.py
@@ -41,14 +41,11 @@ from pdberellig.helpers.utils import (
 class Cofactors:
     """Cofactors pipeline data model."""
 
-    def __init__(self, log, args) -> None:
-        self.log = log
-        self.args = args
-        self.templates = init_rdkit_templates(
-            os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
-        )
-        self.cofactor_details = self._get_cofactor_details()
-        self.cofactor_ec = self._get_cofactor_ec()
+    def __init__(self, ligand_cif, ligand_type, out_dir, logger) -> None:
+        self.ligand_cif = ligand_cif
+        self.ligand_type = ligand_type
+        self.out_dir = out_dir
+        self.logger = logger
 
     def process_entry(self) -> None:
         """Runs cofactor pipeline to check if a ligand
@@ -61,8 +58,13 @@ class Cofactors:
 
         """
         # parse ligand cif file
-        component = parse_ligand(self.args.cif, self.args.ligand_type)
+        component = parse_ligand(self.ligand_cif, self.ligand_type)
         ligand = CompareObj(component.id, component.mol_no_h)
+        templates = init_rdkit_templates(
+            os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
+        )
+        cofactor_details = self._get_cofactor_details()
+        cofactor_details = self._get_cofactor_ec()
 
         # get similarity of the ligand to cofactor templates
         cofactor_sim = self.get_similarity(ligand)
@@ -70,7 +72,7 @@ class Cofactors:
             representative_score = round(
                 cofactor_sim.representative_sim.result.similarity_score, 3
             )
-            self.log.info(
+            self.logger.info(
                 f"Possible new cofactor identified: {cofactor_sim.representative_sim.query_id} similar to"
                 f" {cofactor_sim.representative_sim.target_id} representative with score {representative_score}."
             )
@@ -78,19 +80,19 @@ class Cofactors:
             # get ligand interacting PDB chains, uniprot ids and ec numbers
             ligand_intx_chains = get_ligand_intx_chains(cofactor_sim.query_id)
             if ligand_intx_chains.empty:
-                self.log.warn(f"No interacting PDB chain was found for {ligand.id}")
+                self.logger.warn(f"No interacting PDB chain was found for {ligand.id}")
                 return
             cofactor_template_id = cofactor_sim.template_sim.target_id
-            cofactor_id = self.cofactor_details[cofactor_template_id]["id"]
+            cofactor_id = cofactor_details[cofactor_template_id]["id"]
             ligand_cofactor_ec = pd.merge(
-                self.cofactor_ec.loc[(self.cofactor_ec["COFACTOR_ID"] == cofactor_id)],
+                cofactor_ec.loc[(cofactor_ec["COFACTOR_ID"] == cofactor_id)],
                 ligand_intx_chains,
                 left_on="EC_NO",
                 right_on="ec_number",
             ).drop(columns=["EC_NO"])
 
             if not ligand_cofactor_ec.empty:
-                self.log.info(f"""{cofactor_sim.query_id} is a cofactor-like
+                self.logger.info(f"""{cofactor_sim.query_id} is a cofactor-like
                             molecule similar to the cofactor template {cofactor_template_id}""")
                 cofactor_results = {
                     cofactor_sim.query_id: {
@@ -129,29 +131,48 @@ class Cofactors:
         """
         ligand_id = list(cofactor_results.keys())[0]
         cofactor_results_path = os.path.join(
-            self.args.out_dir, f"{ligand_id}_cofactor_annotation.json"
+            self.out_dir, f"{ligand_id}_cofactor_annotation.json"
         )
-        self.log.info(f"Writing cofactor annotations to {cofactor_results_path}")
+        self.logger.info(f"Writing cofactor annotations to {cofactor_results_path}")
         with open(cofactor_results_path, "w") as fh:
             json.dump(cofactor_results, fh, indent=4)
 
-    def get_similarity(self, ligand: CompareObj) -> Union[CofactorSim, List]:
+    def get_similarity(
+        self,
+        ligand: CompareObj,
+        templates: list[CompareObj] | None = None,
+        cofactor_details: dict | None = None,
+        cofactor_ec: pd.DataFrame | None = None,
+    ) -> Union[CofactorSim, List]:
         """Returns the similarity of query molecule to template and
         representative molecules of cofactor class if it is above defined threshold
 
         Args:
             ligand: CompareObj of ligand
+            templates: List of CompareObj of tempaltes of cofactors
+            cofactor_details: Dictionary of template and representative molecuels of cofactors
+            cofactor_ec: Dataframe of EC numbers associated with cofactors
         """
 
         cofactor_sim = None
+        if not templates:
+            templates = init_rdkit_templates(
+                os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
+            )
+        if not cofactor_details:
+            cofactor_details = self._get_cofactor_details()
+
+        if not cofactor_ec:
+            cofactor_ec = self._get_cofactor_ec()
+
         with ThreadPoolExecutor(max_workers=cpu_count() - 1) as exec:
             future_to_result = {
                 exec.submit(
                     template.similarity_to,
                     ligand,
-                    self.cofactor_details[template.id]["threshold"] - 0.01,
+                    cofactor_details[template.id]["threshold"] - 0.01,
                 ): template.id
-                for template in self.templates
+                for template in templates
             }
 
             for future in as_completed(future_to_result):
@@ -164,7 +185,7 @@ class Cofactors:
                             f"to {template_sim.query_id}"
                         )
 
-                    template_details = self.cofactor_details[template_sim.target_id]
+                    template_details = cofactor_details[template_sim.target_id]
 
                     if (
                         template_sim.result.similarity_score
@@ -173,7 +194,7 @@ class Cofactors:
                         continue
                     template_score = round(template_sim.result.similarity_score, 3)
 
-                    self.log.info(
+                    self.logger.info(
                         f"Possible new cofactor identified: {template_sim.query_id} similar to"
                         f" {template_sim.target_id} template with score {template_score}."
                     )
@@ -207,7 +228,7 @@ class Cofactors:
                             )
 
                 except Exception as exc:
-                    self.log.warn("%r generated an exception: %s" % (template, exc))
+                    self.logger.warn("%r generated an exception: %s" % (template, exc))
 
         return cofactor_sim
 
@@ -242,7 +263,9 @@ class Cofactors:
             representative: representative molecule
         """
 
-        self.log.info(f"Running similarity to representative" f" {representative.id}")
+        self.logger.info(
+            f"Running similarity to representative" f" {representative.id}"
+        )
 
         representative_sim = representative.similarity_to(query)
         if not representative_sim.result:
@@ -253,6 +276,7 @@ class Cofactors:
 
         return representative_sim
 
+    @lru_cache
     def _get_cofactor_details(self) -> dict:
         """Returns the threshold and representative details of cofactor
         classes as dictionary"""
@@ -263,7 +287,7 @@ class Cofactors:
             obj = json.load(f)
             return {x["template"]: x for x in obj}
 
-    @lru_cache(maxsize=None)
+    @lru_cache
     def _get_cofactor_ec(self) -> pd.DataFrame:
         """Returns the EC numbers allowed for cofactor classes"""
         path = os.path.join(get_data_dir(), get_config("cofactor", "ec"))

--- a/pdberellig/core/drugs.py
+++ b/pdberellig/core/drugs.py
@@ -34,22 +34,24 @@ class Drugs:
     Drugs pipeline data model
     """
 
-    def __init__(self, log, args):
-        self.log = log
-        self.args = args
+    def __init__(self, ligand_cif, ligand_type, out_dir, logger):
+        self.ligand_cif = ligand_cif
+        self.ligand_type = ligand_type
+        self.out_dir = out_dir
+        self.logger = logger
 
     def process_entry(self):
-        ligand = parse_ligand(self.args.cif, self.args.ligand_type)
+        ligand = parse_ligand(self.ligand_cif, self.ligand_type)
         drugbank_targets = self.get_drugbank_targets(ligand)
         if drugbank_targets.empty:
-            self.log.info("No target was found for {ligand.id} from DrugBank")
+            self.logger.info("No target was found for {ligand.id} from DrugBank")
             return
 
         drug_targets = drugbank_targets[
             drugbank_targets["pharmacologically_active"] == "yes"
         ]
         if drug_targets.empty:
-            self.log.info(
+            self.logger.info(
                 "None of the targets from DrugBank found for {ligand.id} are pharmacologically active"
             )
             return
@@ -57,7 +59,7 @@ class Drugs:
         # get ligand interacting PDB chains, uniprot ids and ec numbers
         ligand_intx_chains = get_ligand_intx_chains(ligand.id)
         if ligand_intx_chains.empty:
-            self.log.warn(f"No interacting PDB chain was found for {ligand.id}")
+            self.logger.warn(f"No interacting PDB chain was found for {ligand.id}")
             return
 
         ligand_drug_targets = pd.merge(
@@ -69,15 +71,15 @@ class Drugs:
             how="inner",
         )
         if ligand_drug_targets.empty:
-            self.log.info(
+            self.logger.info(
                 f"None of the pharmacologically active targets of {ligand.id} was found in the PDB"
             )
 
         ligand_drug_targets_file = os.path.join(
-            self.args.out_dir, f"{ligand.id}_drug_annotation.tsv"
+            self.out_dir, f"{ligand.id}_drug_annotation.tsv"
         )
 
-        self.log.info(f"Writing drug annotations to {ligand_drug_targets_file}")
+        self.logger.info(f"Writing drug annotations to {ligand_drug_targets_file}")
         ligand_drug_targets.to_csv(ligand_drug_targets_file, sep="\t", index=False)
 
     def get_drugbank_targets(self, component: Component) -> pd.DataFrame:

--- a/pdberellig/core/drugs.py
+++ b/pdberellig/core/drugs.py
@@ -44,7 +44,7 @@ class Drugs:
         ligand = parse_ligand(self.ligand_cif, self.ligand_type)
         drugbank_targets = self.get_drugbank_targets(ligand)
         if drugbank_targets.empty:
-            self.logger.info("No target was found for {ligand.id} from DrugBank")
+            self.logger.info(f"No target was found for {ligand.id} from DrugBank")
             return
 
         drug_targets = drugbank_targets[
@@ -52,7 +52,7 @@ class Drugs:
         ]
         if drug_targets.empty:
             self.logger.info(
-                "None of the targets from DrugBank found for {ligand.id} are pharmacologically active"
+                f"None of the targets from DrugBank found for {ligand.id} are pharmacologically active"
             )
             return
 
@@ -94,7 +94,7 @@ class Drugs:
             "_pdbe_chem_comp_drugbank_targets."
             not in cif_block.get_mmcif_category_names()
         ):
-            return
+            return pd.DataFrame()
         items = ["name", "organism", "uniprot_id", "pharmacologically_active"]
         targets = cif_block.find("_pdbe_chem_comp_drugbank_targets.", items)
         targets_info = defaultdict(list)

--- a/pdberellig/core/reactants.py
+++ b/pdberellig/core/reactants.py
@@ -37,9 +37,23 @@ from pdberellig.helpers.utils import (
 class Reactants:
     """Reactants pipeline data model."""
 
-    def __init__(self, log, args):
-        self.log = log
-        self.args = args
+    def __init__(
+        self,
+        ligand_cif,
+        ligand_type,
+        chebi_structure_file,
+        out_dir,
+        logger,
+        minimal_ligand_size=5,
+        update_chebi=False,
+    ):
+        self.ligand_cif = ligand_cif
+        self.ligand_type = ligand_type
+        self.chebi_structure_file = chebi_structure_file
+        self.out_dir = out_dir
+        self.logger = logger
+        self.minimal_ligand_size = minimal_ligand_size
+        self.update_chebi = update_chebi
 
     def process_entry(self) -> None:
         """
@@ -51,12 +65,12 @@ class Reactants:
         * calculates similarity to reactant participants
         """
 
-        component = parse_ligand(self.args.cif, self.args.ligand_type)
+        component = parse_ligand(self.ligand_cif, self.ligand_type)
         ligand_id = component.id
-        if len(component.mol_no_h.GetAtoms()) < self.args.minimal_ligand_size:
+        if len(component.mol_no_h.GetAtoms()) < self.minimal_ligand_size:
             # ligand is too small.
-            self.log.debug(f"""Number of atoms in {ligand_id} is less than
-                           {self.args.minimal_ligand_size},
+            self.logger.debug(f"""Number of atoms in {ligand_id} is less than
+                           {self.minimal_ligand_size},
                            hence skipping""")
             return
 
@@ -65,7 +79,7 @@ class Reactants:
         # get ligand interacting PDB chains
         intx_chains = get_ligand_intx_chains(ligand.id)
         if intx_chains.empty:
-            self.log.warn(f"No interacting PDB chain was found for {ligand.id}")
+            self.logger.warn(f"No interacting PDB chain was found for {ligand.id}")
             return
 
         uniprot_ids = intx_chains.get("uniprot_id").to_list()
@@ -80,9 +94,9 @@ class Reactants:
                 how="inner",
             )
             reactants_sim_file = os.path.join(
-                self.args.out_dir, f"{ligand.id}_reactant_annotation.tsv"
+                self.out_dir, f"{ligand.id}_reactant_annotation.tsv"
             )
-            self.log.info(f"Writing reactant annotations to {reactants_sim_file}")
+            self.logger.info(f"Writing reactant annotations to {reactants_sim_file}")
             intx_chains_reac_sim.to_csv(reactants_sim_file, sep="\t", index=False)
 
     def get_reactant_annotation(
@@ -105,7 +119,7 @@ class Reactants:
         # get reactions corresponding to the list of uniprot_ids
         reactions = self.get_reactions(uniprot_ids)
         if reactions.empty:
-            self.log.warn(f"No reaction was fetched from Uniprot for {uniprot_ids}")
+            self.logger.warn(f"No reaction was fetched from Uniprot for {uniprot_ids}")
             return pd.DataFrame()
 
         rhea_ids = reactions.get("rhea_id").to_list()
@@ -113,7 +127,7 @@ class Reactants:
         # get ChEBI ids of all the reaction participants
         reaction_participants_df = self.get_reaction_participants(rhea_ids)
         if reaction_participants_df.empty:
-            self.log.warn(
+            self.logger.warn(
                 f"No reaction participants was fetched from Rhea for {rhea_ids}"
             )
             return pd.DataFrame()
@@ -127,7 +141,9 @@ class Reactants:
         chebi_similarities = self.get_similarities(ligand, templates)
         chebi_similarities_df = pd.DataFrame.from_dict(chebi_similarities)
         if chebi_similarities_df.empty:
-            self.log.info(f"No similar reaction participant was found for {ligand.id}")
+            self.logger.info(
+                f"No similar reaction participant was found for {ligand.id}"
+            )
             return pd.DataFrame()
 
         reaction_chebi = pd.merge(
@@ -155,10 +171,10 @@ class Reactants:
         """
 
         templates = []
-        if self.args.chebi_structure_file and not self.args.update_chebi:
-            chebi_structure_file = self.args.chebi_structure_file
+        if self.chebi_structure_file and not self.update_chebi:
+            chebi_structure_file = self.chebi_structure_file
         else:
-            chebi_structure_file = download_chebi(self.args.out_dir)
+            chebi_structure_file = download_chebi(self.out_dir)
 
         self.chebi = pd.read_csv(chebi_structure_file, dtype=str, sep="\t")
         self.chebi = self.chebi.loc[
@@ -173,16 +189,16 @@ class Reactants:
             try:
                 chebi_mol = Chem.MolFromMolBlock(row["molfile"])
                 chebi_mol_no_h = Chem.RemoveHs(chebi_mol)
-                if len(chebi_mol_no_h.GetAtoms()) < self.args.minimal_ligand_size:
+                if len(chebi_mol_no_h.GetAtoms()) < self.minimal_ligand_size:
                     # chebi is too small.
-                    self.log.debug(f"""Number of atoms in {row["compound_id"]} is less
-                                    than {self.args.minimal_ligand_size},
+                    self.logger.debug(f"""Number of atoms in {row["compound_id"]} is less
+                                    than {self.minimal_ligand_size},
                                     hence skipping""")
                 else:
                     templates.append(CompareObj(row["compound_id"], chebi_mol_no_h))
 
             except Exception:
-                self.log.warn(f"Couldn't parse {row['compound_id']} using RDKit")
+                self.logger.warn(f"Couldn't parse {row['compound_id']} using RDKit")
 
         return templates
 
@@ -221,7 +237,7 @@ class Reactants:
                         )
 
                 except Exception as exc:
-                    self.log.warn("%r generated an exception: %s" % (template, exc))
+                    self.logger.warn("%r generated an exception: %s" % (template, exc))
 
         return chebi_similarities
 

--- a/pdberellig/core/reactants.py
+++ b/pdberellig/core/reactants.py
@@ -176,13 +176,11 @@ class Reactants:
         else:
             chebi_structure_file = download_chebi(self.out_dir)
 
-        self.chebi = pd.read_csv(chebi_structure_file, dtype=str, sep="\t")
+        self.chebi = pd.read_csv(chebi_structure_file, sep="\t")
         self.chebi = self.chebi.loc[
             (self.chebi["compound_id"].isin(chebi_ids))
-            & (self.chebi["status_id"] == "1")  # include only ChEBI curated entires
-            & (
-                self.chebi["default_structure"] == "true"
-            ),  # include only with structure
+            & (self.chebi["status_id"] == 1)  # include only ChEBI curated entires
+            & (self.chebi["default_structure"]),  # include only with structure
             ["compound_id", "molfile"],
         ]
         for _, row in self.chebi.iterrows():

--- a/pdberellig/helpers/utils.py
+++ b/pdberellig/helpers/utils.py
@@ -67,6 +67,7 @@ def setup_log(stage, mode):
     return log
 
 
+@lru_cache
 def init_rdkit_templates(path) -> list[CompareObj]:
     """Returns list of templates for cofactor classes.
 

--- a/pdberellig/helpers/utils.py
+++ b/pdberellig/helpers/utils.py
@@ -36,7 +36,7 @@ from requests.adapters import HTTPAdapter
 from SPARQLWrapper import JSON, SPARQLWrapper
 from urllib3 import Retry
 
-from pdberellig.conf import get_config
+from pdberellig.conf import get_config, get_data_dir
 from pdberellig.core.models import CompareObj
 
 
@@ -68,12 +68,9 @@ def setup_log(stage, mode):
 
 
 @lru_cache
-def init_rdkit_templates(path) -> list[CompareObj]:
-    """Returns list of templates for cofactor classes.
-
-    Args:
-        path (str): Path to the directory with templates
-    """
+def init_rdkit_templates() -> list[CompareObj]:
+    """Returns list of templates for cofactor classes."""
+    path = os.path.join(get_data_dir(), get_config("cofactor", "template_path"))
 
     templates = [
         CompareObj(x.split(".")[0], Chem.MolFromMolFile(os.path.join(path, x)))
@@ -81,6 +78,29 @@ def init_rdkit_templates(path) -> list[CompareObj]:
     ]
 
     return templates
+
+
+@lru_cache
+def get_cofactor_details() -> dict:
+    """Returns the threshold and representative details of cofactor
+    classes as dictionary"""
+
+    path = os.path.join(
+        os.path.join(get_data_dir(), get_config("cofactor", "details")),
+    )
+    with open(path) as f:
+        obj = json.load(f)
+        return {x["template"]: x for x in obj}
+
+
+@lru_cache
+def get_cofactor_ec() -> pd.DataFrame:
+    """Returns the EC numbers allowed for cofactor classes"""
+
+    path = os.path.join(get_data_dir(), get_config("cofactor", "ec"))
+    cofactor_ec = pd.read_csv(path, dtype={"EC_NO": str, "COFACTOR_ID": int})
+
+    return cofactor_ec
 
 
 def get_ids_to_process_from_file(file_name: str):

--- a/pdberellig/helpers/utils.py
+++ b/pdberellig/helpers/utils.py
@@ -24,6 +24,7 @@ import logging
 import os
 import sys
 from collections import defaultdict
+from functools import lru_cache
 
 import pandas as pd
 import pdbeccdutils

--- a/pdberellig/helpers/utils.py
+++ b/pdberellig/helpers/utils.py
@@ -20,6 +20,7 @@ Various utilities used in the pipeline
 """
 
 import importlib.metadata
+import json
 import logging
 import os
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdberellig"
-version = "1.0.4"
+version = "2.0.0"
 description = "A toolkit for functional annotation of ligands in the PDB"
 authors = ["Ibrahim Roshan Kunnakkattu <roshan@ebi.ac.uk>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ sphinx-autodoc-typehints = "^1.24.0"
 myst-parser = "^2.0.0"
 sphinx-markdown-tables = "^0.0.17"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def logger():
+    """A logger double that accepts any of the log calls used across the pipelines."""
+    return MagicMock(spec=logging.Logger)

--- a/tests/core/test_cofactors.py
+++ b/tests/core/test_cofactors.py
@@ -1,0 +1,273 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from pdberellig.core import cofactors as cofactors_module
+from pdberellig.core.cofactors import Cofactors
+from pdberellig.core.models import CofactorSim, CompareObj, Similarity
+
+
+def make_cofactors(out_dir, logger, ligand_cif="ignored.cif", ligand_type="CCD"):
+    return Cofactors(ligand_cif, ligand_type, str(out_dir), logger)
+
+
+def make_template(template_id, similarity_score):
+    """A CompareObj whose similarity_to is stubbed instead of running RDKit/PARITY."""
+    template = CompareObj(template_id, None)
+    template.similarity_to = lambda other, threshold=0.01: Similarity(
+        template_id, other.id, SimpleNamespace(similarity_score=similarity_score)
+    )
+    return template
+
+
+class TestGetSimilarity:
+    def test_returns_none_when_no_template_meets_its_threshold(self, tmp_path, logger):
+        cofactors = make_cofactors(tmp_path, logger)
+        ligand = CompareObj("LIG", None)
+        templates = [make_template("FAD", 0.5)]
+        cofactor_details = {
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2}
+        }
+
+        result = cofactors.get_similarity(
+            ligand, templates=templates, cofactor_details=cofactor_details
+        )
+
+        assert result is None
+
+    def test_returns_match_when_template_and_representative_clear_threshold(
+        self, tmp_path, logger, monkeypatch
+    ):
+        cofactors = make_cofactors(tmp_path, logger)
+        ligand = CompareObj("LIG", None)
+        templates = [make_template("FAD", 0.9)]
+        cofactor_details = {
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2}
+        }
+
+        representative = make_template("FAD", 0.9)
+        monkeypatch.setattr(
+            cofactors, "get_representative", lambda details: representative
+        )
+
+        result = cofactors.get_similarity(
+            ligand, templates=templates, cofactor_details=cofactor_details
+        )
+
+        assert isinstance(result, CofactorSim)
+        assert result.query_id == "LIG"
+        assert result.template_sim.target_id == "FAD"
+        assert result.representative_sim.result.similarity_score == 0.9
+
+    def test_skips_when_representative_similarity_below_threshold(
+        self, tmp_path, logger, monkeypatch
+    ):
+        cofactors = make_cofactors(tmp_path, logger)
+        ligand = CompareObj("LIG", None)
+        templates = [make_template("FAD", 0.9)]
+        cofactor_details = {
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2}
+        }
+
+        representative = make_template("FAD", 0.2)
+        monkeypatch.setattr(
+            cofactors, "get_representative", lambda details: representative
+        )
+
+        result = cofactors.get_similarity(
+            ligand, templates=templates, cofactor_details=cofactor_details
+        )
+
+        assert result is None
+
+    def test_picks_the_higher_combined_score_across_multiple_templates(
+        self, tmp_path, logger, monkeypatch
+    ):
+        cofactors = make_cofactors(tmp_path, logger)
+        ligand = CompareObj("LIG", None)
+        templates = [make_template("FAD", 0.9), make_template("NAD2", 0.95)]
+        # representative field is set equal to the template id to keep the
+        # lookup in this test trivial; in production data they can differ.
+        cofactor_details = {
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2},
+            "NAD2": {"threshold": 0.68, "representative": "NAD2", "id": 4},
+        }
+        representative_scores = {"FAD": 0.9, "NAD2": 0.95}
+        monkeypatch.setattr(
+            cofactors,
+            "get_representative",
+            lambda details: make_template(
+                details["representative"],
+                representative_scores[details["representative"]],
+            ),
+        )
+
+        result = cofactors.get_similarity(
+            ligand, templates=templates, cofactor_details=cofactor_details
+        )
+
+        assert result.template_sim.target_id == "NAD2"
+
+    def test_continues_past_template_that_raises(self, tmp_path, logger):
+        cofactors = make_cofactors(tmp_path, logger)
+        ligand = CompareObj("LIG", None)
+
+        broken = CompareObj("BROKEN", None)
+
+        def raise_error(other, threshold):
+            raise RuntimeError("boom")
+
+        broken.similarity_to = raise_error
+        # "good" scores below its own template threshold, so it is skipped via
+        # the normal `continue` path without ever reaching get_representative -
+        # keeping this test deterministic and free of real file I/O.
+        good = make_template("FAD", 0.5)
+        cofactor_details = {
+            "BROKEN": {"threshold": 0.5, "representative": "FAD", "id": 2},
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2},
+        }
+
+        result = cofactors.get_similarity(
+            ligand, templates=[broken, good], cofactor_details=cofactor_details
+        )
+
+        # the exception on "broken" is swallowed and logged; get_similarity
+        # itself must not raise.
+        assert result is None
+        assert logger.warn.called
+
+
+class TestWriteCofactorResults:
+    def test_writes_json_file(self, tmp_path, logger):
+        cofactors = make_cofactors(tmp_path, logger)
+        results = {
+            "LIG": {
+                "template": {"id": "FAD", "similarity": 0.9},
+                "representative": {"id": "FAD", "similarity": 0.9},
+                "pdb_chains": [],
+            }
+        }
+
+        cofactors._write_cofactor_results(results)
+
+        out_file = tmp_path / "LIG_cofactor_annotation.json"
+        assert out_file.exists()
+        import json
+
+        with open(out_file) as fh:
+            assert json.load(fh) == results
+
+
+class TestProcessEntry:
+    @pytest.fixture(autouse=True)
+    def stub_lookup_tables(self, monkeypatch):
+        cofactor_details = {
+            "FAD": {"threshold": 0.87, "representative": "FAD", "id": 2}
+        }
+        cofactor_ec = pd.DataFrame(
+            {"EC_NO": ["1.1.1.1"], "COFACTOR_ID": [2], "SOURCE": ["test"]}
+        )
+        monkeypatch.setattr(cofactors_module, "init_rdkit_templates", lambda: [])
+        monkeypatch.setattr(
+            cofactors_module, "get_cofactor_details", lambda: cofactor_details
+        )
+        monkeypatch.setattr(cofactors_module, "get_cofactor_ec", lambda: cofactor_ec)
+
+    def test_writes_nothing_when_no_cofactor_similarity_found(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=None)
+        monkeypatch.setattr(cofactors_module, "parse_ligand", lambda *a, **k: component)
+
+        cofactors = make_cofactors(tmp_path, logger)
+        monkeypatch.setattr(cofactors, "get_similarity", lambda ligand: None)
+
+        cofactors.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_nothing_when_no_interacting_chains(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=None)
+        monkeypatch.setattr(cofactors_module, "parse_ligand", lambda *a, **k: component)
+
+        sim = CofactorSim(
+            "LIG",
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+        )
+        cofactors = make_cofactors(tmp_path, logger)
+        monkeypatch.setattr(cofactors, "get_similarity", lambda ligand: sim)
+        monkeypatch.setattr(
+            cofactors_module, "get_ligand_intx_chains", lambda ligand_id: pd.DataFrame()
+        )
+
+        cofactors.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+        logger.warn.assert_called_once()
+
+    def test_writes_nothing_when_ec_numbers_do_not_overlap(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=None)
+        monkeypatch.setattr(cofactors_module, "parse_ligand", lambda *a, **k: component)
+
+        sim = CofactorSim(
+            "LIG",
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+        )
+        cofactors = make_cofactors(tmp_path, logger)
+        monkeypatch.setattr(cofactors, "get_similarity", lambda ligand: sim)
+
+        intx_chains = pd.DataFrame(
+            {
+                "pdb_id": ["1abc"],
+                "auth_asym_id": ["A"],
+                "struct_asym_id": ["A"],
+                "uniprot_id": ["P12345"],
+                "ec_number": ["9.9.9.9"],  # does not overlap with cofactor_ec fixture
+            }
+        )
+        monkeypatch.setattr(
+            cofactors_module, "get_ligand_intx_chains", lambda ligand_id: intx_chains
+        )
+
+        cofactors.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_results_when_ec_numbers_overlap(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=None)
+        monkeypatch.setattr(cofactors_module, "parse_ligand", lambda *a, **k: component)
+
+        sim = CofactorSim(
+            "LIG",
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+            Similarity("FAD", "LIG", SimpleNamespace(similarity_score=0.9)),
+        )
+        cofactors = make_cofactors(tmp_path, logger)
+        monkeypatch.setattr(cofactors, "get_similarity", lambda ligand: sim)
+
+        intx_chains = pd.DataFrame(
+            {
+                "pdb_id": ["1abc"],
+                "auth_asym_id": ["A"],
+                "struct_asym_id": ["A"],
+                "uniprot_id": ["P12345"],
+                "ec_number": ["1.1.1.1"],  # overlaps with cofactor_ec fixture
+            }
+        )
+        monkeypatch.setattr(
+            cofactors_module, "get_ligand_intx_chains", lambda ligand_id: intx_chains
+        )
+
+        cofactors.process_entry()
+
+        out_file = tmp_path / "LIG_cofactor_annotation.json"
+        assert out_file.exists()

--- a/tests/core/test_drugs.py
+++ b/tests/core/test_drugs.py
@@ -1,0 +1,169 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from pdberellig.core import drugs as drugs_module
+from pdberellig.core.drugs import Drugs
+
+
+class FakeCifBlock:
+    """Stands in for gemmi's cif block used by Component.ccd_cif_block."""
+
+    def __init__(self, categories, rows=None):
+        self._categories = categories
+        self._rows = rows or []
+
+    def get_mmcif_category_names(self):
+        return self._categories
+
+    def find(self, category, items):
+        return self._rows
+
+
+def make_ligand(ligand_id, cif_block):
+    return SimpleNamespace(id=ligand_id, ccd_cif_block=cif_block)
+
+
+@pytest.fixture(autouse=True)
+def identity_as_string(monkeypatch):
+    """Real gemmi cif values are CIF-quoted strings; rows in these tests are
+    already plain strings, so as_string just needs to pass them through."""
+    monkeypatch.setattr(drugs_module.cif, "as_string", lambda value: value)
+
+
+def make_drugs(out_dir, logger, ligand_cif="ignored.cif", ligand_type="CCD"):
+    return Drugs(ligand_cif, ligand_type, str(out_dir), logger)
+
+
+class TestGetDrugbankTargets:
+    def test_returns_empty_dataframe_when_category_absent(self, tmp_path, logger):
+        drugs = make_drugs(tmp_path, logger)
+        component = make_ligand("LIG", FakeCifBlock(categories=[]))
+
+        result = drugs.get_drugbank_targets(component)
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+
+    def test_returns_targets_when_category_present(self, tmp_path, logger):
+        rows = [
+            {
+                "_pdbe_chem_comp_drugbank_targets.name": "Target A",
+                "_pdbe_chem_comp_drugbank_targets.organism": "Human",
+                "_pdbe_chem_comp_drugbank_targets.uniprot_id": "P12345",
+                "_pdbe_chem_comp_drugbank_targets.pharmacologically_active": "yes",
+            }
+        ]
+        cif_block = FakeCifBlock(
+            categories=["_pdbe_chem_comp_drugbank_targets."], rows=rows
+        )
+        drugs = make_drugs(tmp_path, logger)
+        component = make_ligand("LIG", cif_block)
+
+        result = drugs.get_drugbank_targets(component)
+
+        assert list(result["uniprot_id"]) == ["P12345"]
+        assert list(result["pharmacologically_active"]) == ["yes"]
+
+
+class TestProcessEntry:
+    def test_no_drugbank_targets_writes_nothing(self, tmp_path, logger, monkeypatch):
+        component = make_ligand("LIG", FakeCifBlock(categories=[]))
+        monkeypatch.setattr(drugs_module, "parse_ligand", lambda *a, **k: component)
+
+        drugs = make_drugs(tmp_path, logger)
+        drugs.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+        logger.info.assert_called_once()
+
+    def test_no_pharmacologically_active_targets_writes_nothing(
+        self, tmp_path, logger, monkeypatch
+    ):
+        rows = [
+            {
+                "_pdbe_chem_comp_drugbank_targets.name": "Target A",
+                "_pdbe_chem_comp_drugbank_targets.organism": "Human",
+                "_pdbe_chem_comp_drugbank_targets.uniprot_id": "P12345",
+                "_pdbe_chem_comp_drugbank_targets.pharmacologically_active": "no",
+            }
+        ]
+        cif_block = FakeCifBlock(
+            categories=["_pdbe_chem_comp_drugbank_targets."], rows=rows
+        )
+        component = make_ligand("LIG", cif_block)
+        monkeypatch.setattr(drugs_module, "parse_ligand", lambda *a, **k: component)
+
+        drugs = make_drugs(tmp_path, logger)
+        drugs.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_no_interacting_chains_writes_nothing(self, tmp_path, logger, monkeypatch):
+        rows = [
+            {
+                "_pdbe_chem_comp_drugbank_targets.name": "Target A",
+                "_pdbe_chem_comp_drugbank_targets.organism": "Human",
+                "_pdbe_chem_comp_drugbank_targets.uniprot_id": "P12345",
+                "_pdbe_chem_comp_drugbank_targets.pharmacologically_active": "yes",
+            }
+        ]
+        cif_block = FakeCifBlock(
+            categories=["_pdbe_chem_comp_drugbank_targets."], rows=rows
+        )
+        component = make_ligand("LIG", cif_block)
+        monkeypatch.setattr(drugs_module, "parse_ligand", lambda *a, **k: component)
+        monkeypatch.setattr(
+            drugs_module, "get_ligand_intx_chains", lambda ligand_id: pd.DataFrame()
+        )
+
+        drugs = make_drugs(tmp_path, logger)
+        drugs.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+        logger.warn.assert_called_once()
+
+    def test_full_pipeline_writes_matched_targets(self, tmp_path, logger, monkeypatch):
+        rows = [
+            {
+                "_pdbe_chem_comp_drugbank_targets.name": "Target A",
+                "_pdbe_chem_comp_drugbank_targets.organism": "Human",
+                "_pdbe_chem_comp_drugbank_targets.uniprot_id": "P12345",
+                "_pdbe_chem_comp_drugbank_targets.pharmacologically_active": "yes",
+            },
+            {
+                "_pdbe_chem_comp_drugbank_targets.name": "Target B",
+                "_pdbe_chem_comp_drugbank_targets.organism": "Mouse",
+                "_pdbe_chem_comp_drugbank_targets.uniprot_id": "Q99999",
+                "_pdbe_chem_comp_drugbank_targets.pharmacologically_active": "no",
+            },
+        ]
+        cif_block = FakeCifBlock(
+            categories=["_pdbe_chem_comp_drugbank_targets."], rows=rows
+        )
+        component = make_ligand("LIG", cif_block)
+        monkeypatch.setattr(drugs_module, "parse_ligand", lambda *a, **k: component)
+
+        intx_chains = pd.DataFrame(
+            {
+                "pdb_id": ["1abc"],
+                "auth_asym_id": ["A"],
+                "struct_asym_id": ["A"],
+                "uniprot_id": ["P12345"],
+            }
+        )
+        monkeypatch.setattr(
+            drugs_module, "get_ligand_intx_chains", lambda ligand_id: intx_chains
+        )
+
+        drugs = make_drugs(tmp_path, logger)
+        drugs.process_entry()
+
+        out_file = tmp_path / "LIG_drug_annotation.tsv"
+        assert out_file.exists()
+        result = pd.read_csv(out_file, sep="\t")
+        assert list(result["uniprot_id"]) == ["P12345"]
+        assert list(result["name"]) == ["Target A"]
+        # the non-pharmacologically-active target must not leak into the output
+        assert "Q99999" not in result["uniprot_id"].to_list()

--- a/tests/core/test_reactants.py
+++ b/tests/core/test_reactants.py
@@ -1,0 +1,285 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from rdkit import Chem
+
+from pdberellig.core import reactants as reactants_module
+from pdberellig.core.models import CompareObj, Similarity
+from pdberellig.core.reactants import Reactants
+
+
+class FakeMol:
+    """Stands in for an RDKit Mol; only GetAtoms() is exercised by the pipeline."""
+
+    def __init__(self, num_atoms):
+        self._num_atoms = num_atoms
+
+    def GetAtoms(self):
+        return list(range(self._num_atoms))
+
+
+def make_reactants(out_dir, logger, **kwargs):
+    defaults = dict(
+        ligand_cif="ignored.cif",
+        ligand_type="CCD",
+        chebi_structure_file=None,
+        out_dir=str(out_dir),
+        logger=logger,
+        minimal_ligand_size=5,
+        update_chebi=False,
+    )
+    defaults.update(kwargs)
+    return Reactants(**defaults)
+
+
+def make_template(template_id, similarity_score):
+    template = CompareObj(template_id, None)
+    template.similarity_to = lambda other, threshold=0.01: Similarity(
+        template_id, other.id, SimpleNamespace(similarity_score=similarity_score)
+    )
+    return template
+
+
+class TestProcessEntry:
+    def test_skips_ligand_smaller_than_minimal_size(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=FakeMol(3))
+        monkeypatch.setattr(reactants_module, "parse_ligand", lambda *a, **k: component)
+
+        reactants = make_reactants(tmp_path, logger, minimal_ligand_size=5)
+        reactants.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+        logger.debug.assert_called_once()
+
+    def test_writes_nothing_when_no_interacting_chains(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=FakeMol(10))
+        monkeypatch.setattr(reactants_module, "parse_ligand", lambda *a, **k: component)
+        monkeypatch.setattr(
+            reactants_module,
+            "get_ligand_intx_chains",
+            lambda ligand_id: pd.DataFrame(),
+        )
+
+        reactants = make_reactants(tmp_path, logger)
+        reactants.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+        logger.warn.assert_called_once()
+
+    def test_writes_nothing_when_reactant_annotation_is_empty(
+        self, tmp_path, logger, monkeypatch
+    ):
+        component = SimpleNamespace(id="LIG", mol_no_h=FakeMol(10))
+        monkeypatch.setattr(reactants_module, "parse_ligand", lambda *a, **k: component)
+        intx_chains = pd.DataFrame(
+            {
+                "pdb_id": ["1abc"],
+                "auth_asym_id": ["A"],
+                "struct_asym_id": ["A"],
+                "uniprot_id": ["P12345"],
+            }
+        )
+        monkeypatch.setattr(
+            reactants_module,
+            "get_ligand_intx_chains",
+            lambda ligand_id: intx_chains,
+        )
+
+        reactants = make_reactants(tmp_path, logger)
+        monkeypatch.setattr(
+            reactants,
+            "get_reactant_annotation",
+            lambda ligand, uniprot_ids: pd.DataFrame(),
+        )
+        reactants.process_entry()
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_merged_annotation_on_success(self, tmp_path, logger, monkeypatch):
+        component = SimpleNamespace(id="LIG", mol_no_h=FakeMol(10))
+        monkeypatch.setattr(reactants_module, "parse_ligand", lambda *a, **k: component)
+        intx_chains = pd.DataFrame(
+            {
+                "pdb_id": ["1abc"],
+                "auth_asym_id": ["A"],
+                "struct_asym_id": ["A"],
+                "uniprot_id": ["P12345"],
+            }
+        )
+        monkeypatch.setattr(
+            reactants_module,
+            "get_ligand_intx_chains",
+            lambda ligand_id: intx_chains,
+        )
+
+        reactants_sim = pd.DataFrame(
+            {
+                "uniprot_id": ["P12345"],
+                "rhea_id": ["12345"],
+                "chebi_id": ["CHEBI:1"],
+                "similarity": [0.8],
+            }
+        )
+        reactants = make_reactants(tmp_path, logger)
+        monkeypatch.setattr(
+            reactants,
+            "get_reactant_annotation",
+            lambda ligand, uniprot_ids: reactants_sim,
+        )
+        reactants.process_entry()
+
+        out_file = tmp_path / "LIG_reactant_annotation.tsv"
+        assert out_file.exists()
+        result = pd.read_csv(out_file, sep="\t")
+        assert list(result["pdb_id"]) == ["1abc"]
+        assert list(result["chebi_id"]) == ["CHEBI:1"]
+
+
+class TestGetReactantAnnotation:
+    def test_returns_empty_when_no_reactions_found(self, tmp_path, logger, monkeypatch):
+        reactants = make_reactants(tmp_path, logger)
+        monkeypatch.setattr(
+            reactants, "get_reactions", lambda uniprot_ids: pd.DataFrame()
+        )
+
+        result = reactants.get_reactant_annotation(CompareObj("LIG", None), ["P12345"])
+
+        assert result.empty
+        logger.warn.assert_called_once()
+
+    def test_returns_empty_when_no_reaction_participants_found(
+        self, tmp_path, logger, monkeypatch
+    ):
+        reactants = make_reactants(tmp_path, logger)
+        reactions = pd.DataFrame({"uniprot_id": ["P12345"], "rhea_id": ["12345"]})
+        monkeypatch.setattr(reactants, "get_reactions", lambda uniprot_ids: reactions)
+        monkeypatch.setattr(
+            reactants, "get_reaction_participants", lambda rhea_ids: pd.DataFrame()
+        )
+
+        result = reactants.get_reactant_annotation(CompareObj("LIG", None), ["P12345"])
+
+        assert result.empty
+        logger.warn.assert_called_once()
+
+    def test_returns_empty_when_no_similar_participant_found(
+        self, tmp_path, logger, monkeypatch
+    ):
+        reactants = make_reactants(tmp_path, logger)
+        reactions = pd.DataFrame({"uniprot_id": ["P12345"], "rhea_id": ["12345"]})
+        participants = pd.DataFrame({"rhea_id": ["12345"], "chebi_id": ["CHEBI:1"]})
+        monkeypatch.setattr(reactants, "get_reactions", lambda uniprot_ids: reactions)
+        monkeypatch.setattr(
+            reactants, "get_reaction_participants", lambda rhea_ids: participants
+        )
+        monkeypatch.setattr(reactants, "parse_chebi", lambda chebi_ids: [])
+        monkeypatch.setattr(reactants, "get_similarities", lambda ligand, templates: {})
+
+        result = reactants.get_reactant_annotation(CompareObj("LIG", None), ["P12345"])
+
+        assert result.empty
+        logger.info.assert_called_once()
+
+    def test_merges_reactions_participants_and_similarities(
+        self, tmp_path, logger, monkeypatch
+    ):
+        reactants = make_reactants(tmp_path, logger)
+        reactions = pd.DataFrame({"uniprot_id": ["P12345"], "rhea_id": ["12345"]})
+        participants = pd.DataFrame({"rhea_id": ["12345"], "chebi_id": ["CHEBI:1"]})
+        monkeypatch.setattr(reactants, "get_reactions", lambda uniprot_ids: reactions)
+        monkeypatch.setattr(
+            reactants, "get_reaction_participants", lambda rhea_ids: participants
+        )
+        monkeypatch.setattr(reactants, "parse_chebi", lambda chebi_ids: [])
+        monkeypatch.setattr(
+            reactants,
+            "get_similarities",
+            lambda ligand, templates: {"chebi_id": ["CHEBI:1"], "similarity": [0.9]},
+        )
+
+        result = reactants.get_reactant_annotation(CompareObj("LIG", None), ["P12345"])
+
+        assert list(result["uniprot_id"]) == ["P12345"]
+        assert list(result["chebi_id"]) == ["CHEBI:1"]
+        assert list(result["similarity"]) == [0.9]
+
+
+class TestParseChebi:
+    def _write_chebi_tsv(self, path, rows):
+        pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+
+    def test_filters_by_status_default_structure_and_size(self, tmp_path, logger):
+        big_molfile = Chem.MolToMolBlock(
+            Chem.MolFromSmiles("c1ccccc1")
+        )  # benzene, 6 heavy atoms
+        small_molfile = Chem.MolToMolBlock(
+            Chem.MolFromSmiles("O")
+        )  # water, 1 heavy atom
+
+        chebi_file = tmp_path / "structures.tsv"
+        self._write_chebi_tsv(
+            chebi_file,
+            {
+                "compound_id": ["CHEBI:1", "CHEBI:2", "CHEBI:3", "CHEBI:4"],
+                "status_id": ["1", "0", "1", "1"],  # CHEBI:2 excluded: not curated
+                "default_structure": [
+                    "true",
+                    "true",
+                    "false",
+                    "true",
+                ],  # CHEBI:3 excluded
+                "molfile": [big_molfile, big_molfile, big_molfile, small_molfile],
+            },
+        )
+
+        reactants = make_reactants(
+            tmp_path,
+            logger,
+            chebi_structure_file=str(chebi_file),
+            minimal_ligand_size=5,
+        )
+
+        templates = reactants.parse_chebi(["CHEBI:1", "CHEBI:2", "CHEBI:3", "CHEBI:4"])
+
+        # only CHEBI:1 passes all filters: curated, default structure, big enough
+        assert [t.id for t in templates] == ["CHEBI:1"]
+        # CHEBI:4 was filtered out for being too small, and should be logged
+        logger.debug.assert_called_once()
+
+    def test_skips_unparseable_molfile(self, tmp_path, logger):
+        chebi_file = tmp_path / "structures.tsv"
+        self._write_chebi_tsv(
+            chebi_file,
+            {
+                "compound_id": ["CHEBI:1"],
+                "status_id": ["1"],
+                "default_structure": ["true"],
+                "molfile": ["not a valid molfile"],
+            },
+        )
+
+        reactants = make_reactants(
+            tmp_path, logger, chebi_structure_file=str(chebi_file)
+        )
+
+        templates = reactants.parse_chebi(["CHEBI:1"])
+
+        assert templates == []
+        logger.warn.assert_called_once()
+
+
+class TestGetSimilarities:
+    def test_keeps_only_templates_above_threshold(self, tmp_path, logger):
+        reactants = make_reactants(tmp_path, logger)
+        # main.reactants_threshold in conf.ini is 0.7
+        templates = [make_template("CHEBI:1", 0.9), make_template("CHEBI:2", 0.3)]
+
+        result = reactants.get_similarities(CompareObj("LIG", None), templates)
+
+        assert result["chebi_id"] == ["CHEBI:1"]
+        assert result["similarity"] == [0.9]


### PR DESCRIPTION
- **Breaking:** `Cofactors`, `Reactants`, and `Drugs` pipeline classes now take
  explicit constructor arguments (`ligand_cif`, `ligand_type`, `out_dir`, `logger`,
  etc.) instead of an `argparse.Namespace` object, so they can be used
  programmatically without going through the CLI.
- Cofactor reference data (RDKit templates, cofactor details, and EC numbers) is
  now loaded via cached module-level functions (`init_rdkit_templates`,
  `get_cofactor_details`, `get_cofactor_ec` in `pdberellig.helpers.utils`) instead
  of being loaded once per `Cofactors` instance.
- ChEBI structure file is now parsed using its native/perceived data types
  instead of forcing every column to `str`, fixing comparisons against
  `status_id` and `default_structure`.